### PR TITLE
Added caching of weather data

### DIFF
--- a/app/svelte/src/routes/upcomming.svelte
+++ b/app/svelte/src/routes/upcomming.svelte
@@ -1,9 +1,9 @@
 <script context="module" lang="ts">
-	import type { Load } from '@sveltejs/kit';
+    import type {Load} from '@sveltejs/kit';
 
     let cachedWeather: any
 
-    export const load: Load = async ({ fetch }) => {
+    export const load: Load = async ({fetch}) => {
 
         if (cachedWeather) {
             return cachedWeather
@@ -11,7 +11,7 @@
         const url = `https://idlab.osoc.be/weather/Brussels`;
         const response = await fetch(url);
 
-        console.log({ response });
+        console.log({response});
         cachedWeather = {
             status: response.status,
             props: {
@@ -23,29 +23,29 @@
 </script>
 
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { Temporal } from '@js-temporal/polyfill';
+    import {onMount} from 'svelte';
+    import {Temporal} from '@js-temporal/polyfill';
 
-	import Calendar from '$lib/components/Calendar.svelte';
-	import { type RdfWeatherData, Weather } from '$lib/utils/parseWeather';
+    import Calendar from '$lib/components/Calendar.svelte';
+    import {type RdfWeatherData, Weather} from '$lib/utils/parseWeather';
 
-	export let rdfWeatherArray: RdfWeatherData[];
+    export let rdfWeatherArray: RdfWeatherData[];
 
-	const today = Temporal.Now.plainDateISO();
-	let startOfWeek: Temporal.PlainDate;
-	let weather: Weather;
+    const today = Temporal.Now.plainDateISO();
+    let startOfWeek: Temporal.PlainDate;
+    let weather: Weather;
 
-	function gotoToday() {
-		startOfWeek = today.subtract({ days: today.dayOfWeek - 1 });
-		return startOfWeek;
-	}
+    function gotoToday() {
+        startOfWeek = today.subtract({days: today.dayOfWeek - 1});
+        return startOfWeek;
+    }
 
-	// On load
-	onMount(async () => {
-		weather = Weather.fromRDF(rdfWeatherArray);
+    // On load
+    onMount(async () => {
+        weather = Weather.fromRDF(rdfWeatherArray);
 
-		gotoToday();
-	});
+        gotoToday();
+    });
 </script>
 
-<Calendar {startOfWeek} {weather} />
+<Calendar {startOfWeek} {weather}/>

--- a/app/svelte/src/routes/upcomming.svelte
+++ b/app/svelte/src/routes/upcomming.svelte
@@ -1,12 +1,19 @@
 <script context="module" lang="ts">
 	import type { Load } from '@sveltejs/kit';
 
-	let cachedWeather: any;
+	interface CachedWeather {
+		status: number;
+		props: { rdfWeatherArray?: RdfWeatherData[] };
+	}
+
+	let cachedWeather: CachedWeather;
 
 	export const load: Load = async ({ fetch }) => {
 		if (cachedWeather) {
 			return cachedWeather;
 		}
+
+		// TODO: remove hardcoded location
 		const url = `https://idlab.osoc.be/weather/Brussels`;
 		const response = await fetch(url);
 
@@ -27,7 +34,7 @@
 	import Calendar from '$lib/components/Calendar.svelte';
 	import { type RdfWeatherData, Weather } from '$lib/utils/parseWeather';
 
-	export let rdfWeatherArray: RdfWeatherData[];
+	export let rdfWeatherArray: RdfWeatherData[] = [];
 
 	const today = Temporal.Now.plainDateISO();
 	let startOfWeek: Temporal.PlainDate;

--- a/app/svelte/src/routes/upcomming.svelte
+++ b/app/svelte/src/routes/upcomming.svelte
@@ -1,51 +1,49 @@
 <script context="module" lang="ts">
-    import type {Load} from '@sveltejs/kit';
+	import type { Load } from '@sveltejs/kit';
 
-    let cachedWeather: any
+	let cachedWeather: any;
 
-    export const load: Load = async ({fetch}) => {
+	export const load: Load = async ({ fetch }) => {
+		if (cachedWeather) {
+			return cachedWeather;
+		}
+		const url = `https://idlab.osoc.be/weather/Brussels`;
+		const response = await fetch(url);
 
-        if (cachedWeather) {
-            return cachedWeather
-        }
-        const url = `https://idlab.osoc.be/weather/Brussels`;
-        const response = await fetch(url);
-
-        console.log({response});
-        cachedWeather = {
-            status: response.status,
-            props: {
-                rdfWeatherArray: response.ok && (await response.json())
-            }
-        };
-        return cachedWeather
-    };
+		cachedWeather = {
+			status: response.status,
+			props: {
+				rdfWeatherArray: response.ok && (await response.json())
+			}
+		};
+		return cachedWeather;
+	};
 </script>
 
 <script lang="ts">
-    import {onMount} from 'svelte';
-    import {Temporal} from '@js-temporal/polyfill';
+	import { onMount } from 'svelte';
+	import { Temporal } from '@js-temporal/polyfill';
 
-    import Calendar from '$lib/components/Calendar.svelte';
-    import {type RdfWeatherData, Weather} from '$lib/utils/parseWeather';
+	import Calendar from '$lib/components/Calendar.svelte';
+	import { type RdfWeatherData, Weather } from '$lib/utils/parseWeather';
 
-    export let rdfWeatherArray: RdfWeatherData[];
+	export let rdfWeatherArray: RdfWeatherData[];
 
-    const today = Temporal.Now.plainDateISO();
-    let startOfWeek: Temporal.PlainDate;
-    let weather: Weather;
+	const today = Temporal.Now.plainDateISO();
+	let startOfWeek: Temporal.PlainDate;
+	let weather: Weather;
 
-    function gotoToday() {
-        startOfWeek = today.subtract({days: today.dayOfWeek - 1});
-        return startOfWeek;
-    }
+	function gotoToday() {
+		startOfWeek = today.subtract({ days: today.dayOfWeek - 1 });
+		return startOfWeek;
+	}
 
-    // On load
-    onMount(async () => {
-        weather = Weather.fromRDF(rdfWeatherArray);
+	// On load
+	onMount(async () => {
+		weather = Weather.fromRDF(rdfWeatherArray);
 
-        gotoToday();
-    });
+		gotoToday();
+	});
 </script>
 
-<Calendar {startOfWeek} {weather}/>
+<Calendar {startOfWeek} {weather} />

--- a/app/svelte/src/routes/upcomming.svelte
+++ b/app/svelte/src/routes/upcomming.svelte
@@ -1,17 +1,25 @@
 <script context="module" lang="ts">
 	import type { Load } from '@sveltejs/kit';
 
-	export const load: Load = async ({ fetch }) => {
-		const url = `https://idlab.osoc.be/weather/Brussels`;
-		const response = await fetch(url);
+    let cachedWeather: any
 
-		return {
-			status: response.status,
-			props: {
-				rdfWeatherArray: response.ok && (await response.json())
-			}
-		};
-	};
+    export const load: Load = async ({ fetch }) => {
+
+        if (cachedWeather) {
+            return cachedWeather
+        }
+        const url = `https://idlab.osoc.be/weather/Brussels`;
+        const response = await fetch(url);
+
+        console.log({ response });
+        cachedWeather = {
+            status: response.status,
+            props: {
+                rdfWeatherArray: response.ok && (await response.json())
+            }
+        };
+        return cachedWeather
+    };
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
If we don't cache(save) the weather data after the first API call we would have to wait for a *very* long time every time we switch the calendar views.